### PR TITLE
feat(preset-html5): list type attribute support

### DIFF
--- a/packages/bbob-preset-html5/src/defaultTags.js
+++ b/packages/bbob-preset-html5/src/defaultTags.js
@@ -125,8 +125,10 @@ export default {
     content: node.content,
   }),
   list: node => ({
-    tag: 'ul',
-    attrs: {},
+    tag: getUniqAttr(node.attrs) ? 'ol' : 'ul',
+    attrs: getUniqAttr(node.attrs) ? {
+      type: getUniqAttr(node.attrs),
+    } : {},
     content: asListItems(node.content),
   }),
 };

--- a/packages/bbob-preset-html5/test/index.test.js
+++ b/packages/bbob-preset-html5/test/index.test.js
@@ -99,6 +99,20 @@ describe('@bbob/preset-html5', () => {
     expect(parse(input)).toBe(result);
   });
 
+  test('[list=1][/list]', () => {
+    const input = `[list=1][/list]`;
+    const result = `<ol type="1"></ol>`;
+
+    expect(parse(input)).toBe(result);
+  });
+
+  test('[list=A][/list]', () => {
+    const input = `[list=A][/list]`;
+    const result = `<ol type="A"></ol>`;
+
+    expect(parse(input)).toBe(result);
+  });
+
   test(`[table][/table]`, () => {
     const input = `[table][tr][td]table 1[/td][td]table 2[/td][/tr][tr][td]table 3[/td][td]table 4[/td][/tr][/table]`;
     const result = `<table><tr><td>table 1</td><td>table 2</td></tr><tr><td>table 3</td><td>table 4</td></tr></table>`;


### PR DESCRIPTION
now you can use [list=1] or [list=A] to produce <ol type="A"></ol> lists

fixes #8