### PR TITLE
fix(parser): fix issue with escaping backslashes when enableEscapeTags is set

### DIFF
--- a/packages/bbob-parser/src/lexer.js
+++ b/packages/bbob-parser/src/lexer.js
@@ -53,7 +53,7 @@ function createLexer(buffer, options = {}) {
   const RESERVED_CHARS = [closeTag, openTag, QUOTEMARK, BACKSLASH, SPACE, TAB, EQ, N, EM];
   const NOT_CHAR_TOKENS = [
     ...(options.enableEscapeTags ? [BACKSLASH] : []),
-    openTag, SPACE, TAB, N, BACKSLASH,
+    openTag, SPACE, TAB, N,
   ];
   const WHITESPACES = [SPACE, TAB];
   const SPECIAL_CHARS = [EQ, SPACE, TAB];
@@ -162,6 +162,10 @@ function createLexer(buffer, options = {}) {
                && (nextChar === openTag || nextChar === closeTag)) {
       bufferGrabber.skip(); // skip the \ without emitting anything
       bufferGrabber.skip(); // skip past the [ or ] as well
+      emitToken(createToken(TYPE_WORD, nextChar, row, col));
+    } else if (options.enableEscapeTags && currChar === BACKSLASH && nextChar === BACKSLASH) {
+      bufferGrabber.skip(); // skip the first \ without emitting anything
+      bufferGrabber.skip(); // skip past the second \ and emit it
       emitToken(createToken(TYPE_WORD, nextChar, row, col));
     } else if (currChar === openTag) {
       bufferGrabber.skip(); // skip openTag

--- a/packages/bbob-parser/test/lexer.test.js
+++ b/packages/bbob-parser/test/lexer.test.js
@@ -305,6 +305,29 @@ describe('lexer', () => {
     expectOutput(output, tokens);
   });
 
+  test('escaped tag and escaped backslash', () => {
+    const tokenizeEscape = input => (createLexer(input, {
+      enableEscapeTags: true
+    }).tokenize());
+    const input = '\\\\\\[b\\\\\\]test\\\\\\[/b\\\\\\]';
+    const tokens = tokenizeEscape(input);
+    const output = [
+      [TYPE.WORD, '\\', '0', '0'],
+      [TYPE.WORD, '[', '0', '0'],
+      [TYPE.WORD, 'b', '0', '0'],
+      [TYPE.WORD, '\\', '0', '0'],
+      [TYPE.WORD, ']', '0', '0'],
+      [TYPE.WORD, 'test', '0', '0'],
+      [TYPE.WORD, '\\', '0', '0'],
+      [TYPE.WORD, '[', '0', '0'],
+      [TYPE.WORD, '/b', '0', '0'],
+      [TYPE.WORD, '\\', '0', '0'],
+      [TYPE.WORD, ']', '0', '0'],
+    ];
+
+    expectOutput(output, tokens);
+  });
+
   describe('html', () => {
     const tokenizeHTML = input => createLexer(input, { openTag: '<', closeTag: '>' }).tokenize();
 

--- a/packages/bbob-parser/test/parse.test.js
+++ b/packages/bbob-parser/test/parse.test.js
@@ -184,7 +184,7 @@ describe('Parser', () => {
       ]);
     });
 
-    test('parse escaped tags tags', () => {
+    test('parse escaped tags', () => {
       const ast = parse('\\[b\\]test\\[/b\\]', {
         enableEscapeTags: true
       });
@@ -196,6 +196,26 @@ describe('Parser', () => {
         'test',
         '[',
         '/b',
+        ']',
+      ]);
+    });
+
+    test('parse escaped tags and escaped backslash', () => {
+      const ast = parse('\\\\\\[b\\\\\\]test\\\\\\[/b\\\\\\]', {
+        enableEscapeTags: true
+      });
+
+      expectOutput(ast, [
+        '\\',
+        '[',
+        'b',
+        '\\',
+        ']',
+        'test',
+        '\\',
+        '[',
+        '/b',
+        '\\',
         ']',
       ]);
     });


### PR DESCRIPTION
Apologies for the second pull request, as I just realised there is a bug in the escaping code backslashes and tags are not escaped properly. For example, the following bbcode:

`test \\[b]123[/b]` should be parsed to: `'test',' ','\',{btag with 123 as contents}` but it is currently being parsed as an escaped tag, as there is no rule for escaping backslashes.

---

This PR fixes that by adding a rule to escape `\\` and treat it as a single backslash.

Therefore, `test \\[b]123[/b]` will be treated as a literal backslash and a **b** tag
Wheras `test \\\[b\]123\[/b\]` will be treated as a literal backslash, and then an escaped tag