### PR TITLE
chore: v2.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.5.1"></a>
+## [2.5.1](https://github.com/JiLiZART/bbob/compare/v2.4.1...v2.5.1) (2019-06-18)
+
+
+### Bug Fixes
+
+* **parser:** fix issue with escaping backslashes when enableEscapeTags is set ([#20](https://github.com/JiLiZART/bbob/issues/20)) ([8a9e930](https://github.com/JiLiZART/bbob/commit/8a9e930))
+
+
+### Features
+
+* **parse:** allow tags to be escaped with backslash ([#17](https://github.com/JiLiZART/bbob/issues/17)) ([c4f78c1](https://github.com/JiLiZART/bbob/commit/c4f78c1))
+* **preset-html5:** list type attribute support ([#18](https://github.com/JiLiZART/bbob/issues/18)) ([847c55e](https://github.com/JiLiZART/bbob/commit/847c55e))
+
+
+
+
 <a name="2.5.0"></a>
 # [2.5.0](https://github.com/JiLiZART/bbob/compare/v2.4.1...v2.5.0) (2019-06-17)
 

--- a/lerna.json
+++ b/lerna.json
@@ -15,5 +15,5 @@
     "access": "public",
     "registry": "https://registry.npmjs.org/"
   },
-  "version": "2.5.0"
+  "version": "2.5.1"
 }

--- a/packages/bbob-cli/CHANGELOG.md
+++ b/packages/bbob-cli/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.5.1"></a>
+## [2.5.1](https://github.com/JiLiZART/bbob/compare/v2.4.1...v2.5.1) (2019-06-18)
+
+
+
+
+**Note:** Version bump only for package @bbob/cli
+
 <a name="2.5.0"></a>
 # [2.5.0](https://github.com/JiLiZART/bbob/compare/v2.4.1...v2.5.0) (2019-06-17)
 

--- a/packages/bbob-cli/package.json
+++ b/packages/bbob-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbob/cli",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Comand line bbcode parser",
   "main": "lib/cli.js",
   "bin": {
@@ -10,8 +10,8 @@
     "lib": "lib"
   },
   "dependencies": {
-    "@bbob/html": "^2.5.0",
-    "@bbob/preset-html5": "^2.5.0",
+    "@bbob/html": "^2.5.1",
+    "@bbob/preset-html5": "^2.5.1",
     "commander": "^2.15.1"
   },
   "repository": {

--- a/packages/bbob-core/CHANGELOG.md
+++ b/packages/bbob-core/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.5.1"></a>
+## [2.5.1](https://github.com/JiLiZART/bbob/compare/v2.4.1...v2.5.1) (2019-06-18)
+
+
+
+
+**Note:** Version bump only for package @bbob/core
+
 <a name="2.5.0"></a>
 # [2.5.0](https://github.com/JiLiZART/bbob/compare/v2.4.1...v2.5.0) (2019-06-17)
 

--- a/packages/bbob-core/package.json
+++ b/packages/bbob-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbob/core",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "⚡️Blazing fast BBCode transforming and parsing tool in pure javascript, no dependencies ",
   "keywords": [
     "bbcode",
@@ -20,7 +20,7 @@
     "core"
   ],
   "dependencies": {
-    "@bbob/parser": "^2.5.0"
+    "@bbob/parser": "^2.5.1"
   },
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/packages/bbob-html/CHANGELOG.md
+++ b/packages/bbob-html/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.5.1"></a>
+## [2.5.1](https://github.com/JiLiZART/bbob/compare/v2.4.1...v2.5.1) (2019-06-18)
+
+
+
+
+**Note:** Version bump only for package @bbob/html
+
 <a name="2.5.0"></a>
 # [2.5.0](https://github.com/JiLiZART/bbob/compare/v2.4.1...v2.5.0) (2019-06-17)
 

--- a/packages/bbob-html/package.json
+++ b/packages/bbob-html/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@bbob/html",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "HTML renderer for @bbob bbcode parser",
   "keywords": [],
   "dependencies": {
-    "@bbob/core": "^2.5.0",
+    "@bbob/core": "^2.5.1",
     "@bbob/plugin-helper": "^2.4.0"
   },
   "main": "lib/index.js",

--- a/packages/bbob-parser/CHANGELOG.md
+++ b/packages/bbob-parser/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.5.1"></a>
+## [2.5.1](https://github.com/JiLiZART/bbob/compare/v2.4.1...v2.5.1) (2019-06-18)
+
+
+### Bug Fixes
+
+* **parser:** fix issue with escaping backslashes when enableEscapeTags is set ([#20](https://github.com/JiLiZART/bbob/issues/20)) ([8a9e930](https://github.com/JiLiZART/bbob/commit/8a9e930))
+
+
+### Features
+
+* **parse:** allow tags to be escaped with backslash ([#17](https://github.com/JiLiZART/bbob/issues/17)) ([c4f78c1](https://github.com/JiLiZART/bbob/commit/c4f78c1))
+
+
+
+
 <a name="2.5.0"></a>
 # [2.5.0](https://github.com/JiLiZART/bbob/compare/v2.4.1...v2.5.0) (2019-06-17)
 

--- a/packages/bbob-parser/package.json
+++ b/packages/bbob-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbob/parser",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Just parses BBcode to AST array. Part of @bbob bbcode parser",
   "keywords": [
     "bbcode",

--- a/packages/bbob-parser/src/lexer.js
+++ b/packages/bbob-parser/src/lexer.js
@@ -53,7 +53,7 @@ function createLexer(buffer, options = {}) {
   const RESERVED_CHARS = [closeTag, openTag, QUOTEMARK, BACKSLASH, SPACE, TAB, EQ, N, EM];
   const NOT_CHAR_TOKENS = [
     ...(options.enableEscapeTags ? [BACKSLASH] : []),
-    openTag, SPACE, TAB, N, BACKSLASH,
+    openTag, SPACE, TAB, N,
   ];
   const WHITESPACES = [SPACE, TAB];
   const SPECIAL_CHARS = [EQ, SPACE, TAB];
@@ -162,6 +162,10 @@ function createLexer(buffer, options = {}) {
                && (nextChar === openTag || nextChar === closeTag)) {
       bufferGrabber.skip(); // skip the \ without emitting anything
       bufferGrabber.skip(); // skip past the [ or ] as well
+      emitToken(createToken(TYPE_WORD, nextChar, row, col));
+    } else if (options.enableEscapeTags && currChar === BACKSLASH && nextChar === BACKSLASH) {
+      bufferGrabber.skip(); // skip the first \ without emitting anything
+      bufferGrabber.skip(); // skip past the second \ and emit it
       emitToken(createToken(TYPE_WORD, nextChar, row, col));
     } else if (currChar === openTag) {
       bufferGrabber.skip(); // skip openTag

--- a/packages/bbob-parser/test/lexer.test.js
+++ b/packages/bbob-parser/test/lexer.test.js
@@ -305,6 +305,29 @@ describe('lexer', () => {
     expectOutput(output, tokens);
   });
 
+  test('escaped tag and escaped backslash', () => {
+    const tokenizeEscape = input => (createLexer(input, {
+      enableEscapeTags: true
+    }).tokenize());
+    const input = '\\\\\\[b\\\\\\]test\\\\\\[/b\\\\\\]';
+    const tokens = tokenizeEscape(input);
+    const output = [
+      [TYPE.WORD, '\\', '0', '0'],
+      [TYPE.WORD, '[', '0', '0'],
+      [TYPE.WORD, 'b', '0', '0'],
+      [TYPE.WORD, '\\', '0', '0'],
+      [TYPE.WORD, ']', '0', '0'],
+      [TYPE.WORD, 'test', '0', '0'],
+      [TYPE.WORD, '\\', '0', '0'],
+      [TYPE.WORD, '[', '0', '0'],
+      [TYPE.WORD, '/b', '0', '0'],
+      [TYPE.WORD, '\\', '0', '0'],
+      [TYPE.WORD, ']', '0', '0'],
+    ];
+
+    expectOutput(output, tokens);
+  });
+
   describe('html', () => {
     const tokenizeHTML = input => createLexer(input, { openTag: '<', closeTag: '>' }).tokenize();
 

--- a/packages/bbob-parser/test/parse.test.js
+++ b/packages/bbob-parser/test/parse.test.js
@@ -184,7 +184,7 @@ describe('Parser', () => {
       ]);
     });
 
-    test('parse escaped tags tags', () => {
+    test('parse escaped tags', () => {
       const ast = parse('\\[b\\]test\\[/b\\]', {
         enableEscapeTags: true
       });
@@ -196,6 +196,26 @@ describe('Parser', () => {
         'test',
         '[',
         '/b',
+        ']',
+      ]);
+    });
+
+    test('parse escaped tags and escaped backslash', () => {
+      const ast = parse('\\\\\\[b\\\\\\]test\\\\\\[/b\\\\\\]', {
+        enableEscapeTags: true
+      });
+
+      expectOutput(ast, [
+        '\\',
+        '[',
+        'b',
+        '\\',
+        ']',
+        'test',
+        '\\',
+        '[',
+        '/b',
+        '\\',
         ']',
       ]);
     });

--- a/packages/bbob-preset-html5/CHANGELOG.md
+++ b/packages/bbob-preset-html5/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.5.1"></a>
+## [2.5.1](https://github.com/JiLiZART/bbob/compare/v2.4.1...v2.5.1) (2019-06-18)
+
+
+### Features
+
+* **preset-html5:** list type attribute support ([#18](https://github.com/JiLiZART/bbob/issues/18)) ([847c55e](https://github.com/JiLiZART/bbob/commit/847c55e))
+
+
+
+
 <a name="2.5.0"></a>
 # [2.5.0](https://github.com/JiLiZART/bbob/compare/v2.4.1...v2.5.0) (2019-06-17)
 

--- a/packages/bbob-preset-html5/package.json
+++ b/packages/bbob-preset-html5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbob/preset-html5",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "HTML5 preset to transform BBCode to HTML for @bbob/parser",
   "keywords": [
     "preset",
@@ -12,7 +12,7 @@
     "@bbob/preset": "^2.4.0"
   },
   "devDependencies": {
-    "@bbob/html": "^2.5.0"
+    "@bbob/html": "^2.5.1"
   },
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/packages/bbob-preset-react/CHANGELOG.md
+++ b/packages/bbob-preset-react/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.5.1"></a>
+## [2.5.1](https://github.com/JiLiZART/bbob/compare/v2.4.1...v2.5.1) (2019-06-18)
+
+
+
+
+**Note:** Version bump only for package @bbob/preset-react
+
 <a name="2.5.0"></a>
 # [2.5.0](https://github.com/JiLiZART/bbob/compare/v2.4.1...v2.5.0) (2019-06-17)
 

--- a/packages/bbob-preset-react/package.json
+++ b/packages/bbob-preset-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbob/preset-react",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "React preset to transform BBCode to React for @bbob/react",
   "keywords": [
     "bbob",
@@ -8,10 +8,10 @@
     "react"
   ],
   "dependencies": {
-    "@bbob/preset-html5": "^2.5.0"
+    "@bbob/preset-html5": "^2.5.1"
   },
   "devDependencies": {
-    "@bbob/core": "^2.5.0"
+    "@bbob/core": "^2.5.1"
   },
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/packages/bbob-react/CHANGELOG.md
+++ b/packages/bbob-react/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.5.1"></a>
+## [2.5.1](https://github.com/JiLiZART/bbob/compare/v2.4.1...v2.5.1) (2019-06-18)
+
+
+
+
+**Note:** Version bump only for package @bbob/react
+
 <a name="2.5.0"></a>
 # [2.5.0](https://github.com/JiLiZART/bbob/compare/v2.4.1...v2.5.0) (2019-06-17)
 

--- a/packages/bbob-react/package.json
+++ b/packages/bbob-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbob/react",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Render BBCode to React using @bbob/parser",
   "keywords": [
     "react",
@@ -9,8 +9,8 @@
     "bbob"
   ],
   "dependencies": {
-    "@bbob/core": "^2.5.0",
-    "@bbob/html": "^2.5.0",
+    "@bbob/core": "^2.5.1",
+    "@bbob/html": "^2.5.1",
     "@bbob/plugin-helper": "^2.4.0"
   },
   "peerDependencies": {
@@ -18,7 +18,7 @@
     "react": "15.x"
   },
   "devDependencies": {
-    "@bbob/preset-react": "^2.5.0",
+    "@bbob/preset-react": "^2.5.1",
     "enzyme": "^3.9.0",
     "enzyme-adapter-react-15": "^1.0.6",
     "react": "15.x",


### PR DESCRIPTION
…s is set (#20)

there is a bug in the lexer where when enableEscapeTags is set, backslashes
are not always escaped (ie. \\[b] is treated as an escaped tag, rather than a
literal backslash, and then a tag).