### PR TITLE
attrsToString: To avoid some malformed attributes

### DIFF
--- a/packages/bbob-plugin-helper/src/index.js
+++ b/packages/bbob-plugin-helper/src/index.js
@@ -54,7 +54,7 @@ const attrValue = (name, value) => {
  */
 const attrsToString = (values) => {
   // To avoid some malformed attributes
-  if (undefined === values) {
+  if (typeof values === 'undefined') {
     return '';
   }
 

--- a/packages/bbob-plugin-helper/src/index.js
+++ b/packages/bbob-plugin-helper/src/index.js
@@ -54,8 +54,8 @@ const attrValue = (name, value) => {
  */
 const attrsToString = (values) => {
   // To avoid some malformed attributes
-  if (!!values) {
-  	return '';
+  if (undefined === values) {
+    return '';
   }
 
   return Object.keys(values)

--- a/packages/bbob-plugin-helper/src/index.js
+++ b/packages/bbob-plugin-helper/src/index.js
@@ -52,10 +52,16 @@ const attrValue = (name, value) => {
  * Transforms attrs to html params string
  * @param values
  */
-const attrsToString = values =>
-  Object.keys(values)
+const attrsToString = (values) => {
+  // To avoid some malformed attributes
+  if (!!values) {
+  	return '';
+  }
+
+  return Object.keys(values)
     .reduce((arr, key) => [...arr, attrValue(key, values[key])], [''])
     .join(' ');
+};
 
 export {
   attrsToString,

--- a/packages/bbob-plugin-helper/test/index.test.js
+++ b/packages/bbob-plugin-helper/test/index.test.js
@@ -79,4 +79,8 @@ describe('@bbob/plugin-helper', () => {
       disabled: true
     })).toBe(` tag="test" foo="bar" disabled`)
   })
+  
+  test('attrsToString undefined', () => {
+    expect(attrsToString(undefined)).toBe('')
+  })  
 });


### PR DESCRIPTION
Error:
```
TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at attrsToString
```

This errors appears if no `attrs` setted in custom tag:
```js
const BBcodePresetTemp = BbobPresetHTML5.extend((tags: any) => {
	tags.br = () => ({
		tag: 'br',
		// attrs: {}, // <-- Comment this line for error and add [br] to text
		content: null,
	});

	return tags;
});
```

The dirty fix. Should be test and warning added.