### PR TITLE
fix(react): fix broken prop type definition

### DIFF
--- a/packages/bbob-react/src/Component.js
+++ b/packages/bbob-react/src/Component.js
@@ -21,7 +21,7 @@ if (process.env.NODE_ENV !== 'production') {
   Component.propTypes = {
     container: PropTypes.node,
     children: PropTypes.node.isRequired,
-    plugins: PropTypes.arrayOf(Function),
+    plugins: PropTypes.arrayOf(PropTypes.func),
     componentProps: PropTypes.shape({
       className: PropTypes.string,
     }),


### PR DESCRIPTION
You need to pass a valid prop checking function to `PropTypes.arrayOf`. This caused an error to be thrown in development for me:

```
Warning: Failed prop type: Unexpected token function
```