### PR TITLE
docs: correct react preset usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ import reactPreset from "@bbob/preset-react";
 import reactRender from "@bbob/react/es/render";
 
 const preset = reactPreset.extend((tags, options) => ({
+  ...tags,
   quote: node => ({
     tag: "blockquote",
     content: node.content


### PR DESCRIPTION
Users need to spread the `tags` parameter in order to properly `extend` a preset. You can see the internals of `preset-react` for another example.