### PR TITLE
fix(bbob-react): remove `unique "key" prop` warning

### DIFF
--- a/packages/bbob-react/src/render.js
+++ b/packages/bbob-react/src/render.js
@@ -10,19 +10,19 @@ const toAST = (source, plugins, options) => core(plugins)
     render: input => html.render(input, { stripTags: true }),
   }).tree;
 
-function tagToReactElement(node) {
+function tagToReactElement(node, index) {
   return React.createElement(
     node.tag,
-    node.attrs,
+    { ...node.attrs, key: index },
     // eslint-disable-next-line no-use-before-define
     node.content ? renderToReactNodes(node.content) : null,
   );
 }
 
 function renderToReactNodes(nodes) {
-  const els = [].concat(nodes).reduce((arr, node) => {
+  const els = [].concat(nodes).reduce((arr, node, index) => {
     if (isTagNode(node)) {
-      arr.push(tagToReactElement(node));
+      arr.push(tagToReactElement(node, index));
     } else if (isStringNode(node)) {
       arr.push(node);
     }


### PR DESCRIPTION
When using `@bbob/react`s `<BBCode>` component, the following error is thrown if this change is not included...

```
Warning: Each child in a list should have a unique "key" prop.
```

Mentioned in #28