### PR TITLE
fix(plugin-helper): lowercase all tag names so presets pick them up

### DIFF
--- a/packages/bbob-plugin-helper/src/TagNode.js
+++ b/packages/bbob-plugin-helper/src/TagNode.js
@@ -3,7 +3,7 @@ import { getNodeLength, appendToNode } from './index';
 
 class TagNode {
   constructor(tag, attrs, content) {
-    this.tag = tag;
+    this.tag = tag.toLowerCase();
     this.attrs = attrs;
     this.content = [].concat(content);
   }


### PR DESCRIPTION
BBCode is usually specified as lower case and all the presets define lowercase
tags so capitalized tags like `[B]` or `[QUOTE]` won't be handle properly. This
should fix that because the parser uses this constructor/class before any presets
are run.

See #28 for more details.