### PR TITLE
fix(react): adjust PropTypes for React Component `container`

### DIFF
--- a/packages/bbob-react/src/Component.js
+++ b/packages/bbob-react/src/Component.js
@@ -18,7 +18,11 @@ const Component = ({
 
 if (process.env.NODE_ENV !== 'production') {
   Component.propTypes = {
-    container: PropTypes.node,
+    container: PropTypes.oneOfType([
+      PropTypes.node,
+      PropTypes.element,
+      PropTypes.elementType,
+    ]),
     children: PropTypes.node.isRequired,
     plugins: PropTypes.arrayOf(PropTypes.func),
     componentProps: PropTypes.shape({


### PR DESCRIPTION
Augments the existing PropType for the `container` prop of Component to allow for React elements and element types to be passed. The latter allows React Native to better be supported.

Fixes #105 