### PR TITLE
chore: exclude benchmark files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 #Tell Linguist to ignore all benchmark stuff
-benchmark/* linguist-documentation
+benchmark/** linguist-vendored


### PR DESCRIPTION
Hello,
When looking for "bbcode language:javascript" in github search box, I did not find this awesome library at first glance, as it wasn't in the list. Turns out that the exclusion for linguist wasn't working well.

before:
![bbob-stats_before](https://user-images.githubusercontent.com/8985327/135554364-ef69c077-e5a9-424b-a673-e76a011fc440.png)

after the pr, tested in my forked repo:
![bbob-stats_after](https://user-images.githubusercontent.com/8985327/135554372-8ceb04b5-1209-4d8b-9411-89ce253cac97.png)

Hope it helps.;)