### PR TITLE
fix: treat contextFreeTags case insensitively

### DIFF
--- a/.changeset/dry-peas-develop.md
+++ b/.changeset/dry-peas-develop.md
@@ -1,0 +1,5 @@
+---
+"@bbob/parser": minor
+---
+
+fix: treat contextFreeTags case insensitively

--- a/packages/bbob-parser/src/lexer.js
+++ b/packages/bbob-parser/src/lexer.js
@@ -63,7 +63,9 @@ function createLexer(buffer, options = {}) {
   const openTag = options.openTag || OPEN_BRAKET;
   const closeTag = options.closeTag || CLOSE_BRAKET;
   const escapeTags = !!options.enableEscapeTags;
-  const contextFreeTags = options.contextFreeTags || [];
+  const contextFreeTags = (options.contextFreeTags || [])
+    .filter(Boolean)
+    .map((tag) => tag.toLowerCase());
   const onToken = options.onToken || (() => {
   });
 
@@ -92,7 +94,7 @@ function createLexer(buffer, options = {}) {
       contextFreeTag = '';
     }
 
-    if (contextFreeTag === '' && contextFreeTags.includes(name)) {
+    if (contextFreeTag === '' && contextFreeTags.includes(name.toLowerCase())) {
       contextFreeTag = name;
     }
   };

--- a/packages/bbob-parser/test/lexer.test.js
+++ b/packages/bbob-parser/test/lexer.test.js
@@ -482,6 +482,24 @@ describe('lexer', () => {
     expect(tokens).toBeMantchOutput(output);
   })
 
+  test('context free tag case insensitive [CODE]', () => {
+    const input = '[CODE] [b]some string[/b][/CODE]'
+    const tokens = tokenizeContextFreeTags(input, ['code']);
+    const output = [
+      [TYPE.TAG, 'CODE', 0, 0],
+      [TYPE.SPACE, ' ', 0, 0],
+      [TYPE.WORD, '[', 0, 0],
+      [TYPE.WORD, 'b]some', 0, 0],
+      [TYPE.SPACE, ' ', 0, 0],
+      [TYPE.WORD, 'string', 0, 0],
+      [TYPE.WORD, '[', 0, 0],
+      [TYPE.WORD, '/b]', 0, 0],
+      [TYPE.TAG, '/CODE', 0, 0],
+    ]
+
+    expect(tokens).toBeMantchOutput(output);
+  })
+
   test('bad closed tag with escaped backslash', () => {
     const input = `[b]test[\\b]`;
     const tokens = tokenizeEscape(input);


### PR DESCRIPTION
Addresses issue where contextFreeTags option is not treated case insensitively.

This results in odd scenarios where `[code][b]hello world[/b][/code]` works, but not `[CODE][b]hello world[/b][/CODE]` depending on the configured contextFreeTags.

Fix involves adding a `toLowerCase()` on each check for contextFreeTags.